### PR TITLE
Añadir about/sobre templanzas

### DIFF
--- a/app/views/about/index.html
+++ b/app/views/about/index.html
@@ -1,0 +1,11 @@
+{% extends "layout/_simple_site_layout.html" %}
+
+{% block page_content %}
+
+<h1>{{ about.headline }}</h1>
+<p>{{ about.description }}</p>
+
+<h2>This is something else. it should wait until the page has loaded</h2>
+
+</article>
+{% endblock %}

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -8,6 +8,7 @@ export const i18n = {
       {view: `example`, path: `/example`},
       {view: `donate`, path: `/donate`},
       {view: `programs`, path: `/programs`},
+      {view: `about`, path: `/about`},
     ],
   },
   es: {
@@ -19,6 +20,7 @@ export const i18n = {
       {view: `example`, path: `/ejemplo`},
       {view: `donate`, path: `/donar`},
       {view: `programs`, path: `/programas`},
+      {view: `about`, path: `/sobre`},
     ],
   },
 };

--- a/content/en/about.yml
+++ b/content/en/about.yml
@@ -1,0 +1,11 @@
+# Content for site
+# Content appears in the order of page layout
+
+en:
+  about:
+    page_title: "About"
+    page_description: "About page"
+    meta_social_image:
+
+    headline: Hello, World About Page
+    description: This is a description of the about page

--- a/content/es/sobre.yml
+++ b/content/es/sobre.yml
@@ -1,0 +1,11 @@
+# Content for site
+# Content appears in the order of page layout
+
+es:
+  about:
+    page_title: "Sorbre"
+    page_description: "Sobre en Español"
+    meta_social_image:
+
+    headline: Sobre
+

--- a/content/es/sobre.yml
+++ b/content/es/sobre.yml
@@ -3,7 +3,7 @@
 
 es:
   about:
-    page_title: "Sorbre"
+    page_title: "Sobre"
     page_description: "Sobre en Español"
     meta_social_image:
 


### PR DESCRIPTION
### Issues

Este PR añade la templanza para las páginas `about/sobre`. 

### Todos

- [x] @Clarissa0512  y @Mariaa122  tienen que revisar
- [x] Merge #3 antes que este PR

### Áreas impactadas

`en/about`
`es/sobre`

### Pasos para reproducir

- Cambia a la rama. Asegúrese que tiene todos los cambios con `git pull`.
- Instala los cambios de paquetes `yarn`
- Inicia el app `yarn start`. Abre una nueva pestaña y navega a `localhost:8000/en/about` y `localhost:8000/es/sobre`. 💃🏿
