### PR TITLE
Anadir Normalize.css

### DIFF
--- a/app/assets/styles/site.css
+++ b/app/assets/styles/site.css
@@ -1,6 +1,14 @@
 /**
  * @file Site
- * @overview Imports files required to build Storefront pages
+ * @overview Importaciones de CSS para macile.org
  */
 
+
+/* Resets */
+
+/* Normalize está instaldo en /node_modules */
+@import 'normalize.css/normalize.css';
+
+
+/* Módulos Locales  */
 @import 'modules/page';

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "imagemin-pngquant": "^5.0.0",
     "marked": "^0.3.5",
     "modularscale-sass": "^2.1.1",
+    "normalize.css": "^7.0.0",
     "nunjucks-markdown": "^2.0.1",
     "postcss-import": "^10.0.0",
     "postcss-modular-scale": "^2.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4093,6 +4093,10 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+normalize.css@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-7.0.0.tgz#abfb1dd82470674e0322b53ceb1aaf412938e4bf"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"


### PR DESCRIPTION
### Issues

Añadir normalize.css para normalizar los estilos entre los navegadores.

### Todos

- [x] Revisar

### Áreas impactadas

Todas las páginas

### Como Probar

En la rama `master`pueden ver un espacio blanco alrededor de la página. 

- Ahora, cambias a la rama `anadir-normalize`. 
- Instala las dependencias con `yarn`
- Inicia el servidor local `yarn start`
- En localhost:8000 ahora no hay un borde :D 
