### PR TITLE
Hotfixes gulp

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -68,7 +68,7 @@ gulp.task(`data`, () => {
 
 gulp.task(`copy-images`, () =>{
   return gulp.src([
-    `app/assets/img/*.jpg`,
+    `app/assets/img/*`,
   ])
   .pipe(gulp.dest(`.tmp/assets/img`));
 });
@@ -302,7 +302,7 @@ gulp.task(`serve`, () => {
 
   gulp.watch([
     `content/**/*.yml`,
-  ], [`data-update`]).on(`change`, reload);
+  ], [`html:watch`]).on(`change`, reload);
 });
 
 gulp.task(`serve:dist`, () => {
@@ -398,6 +398,7 @@ gulp.task(`default`, (cb) => {
     `clean:tmp`,
     `data`,
     `images`,
+    `copy-images`,
     `styles`,
     `scripts`,
     `html`,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "scripts": {
     "start": "gulp",
+    "html": "gulp html",
+    "styles": "gulp styles",
+    "images": "gulp copy-images",
     "test": "echo \"Error: no test specified\" && exit 1",
     "postversion": "git push && git push --tags"
   },


### PR DESCRIPTION
### Issues

- Imágenes jpg no se copiaban correctamente
- Al editar yaml el navegador no estaba refrescando porque la tarea cambio de nombre
- Algunas máquinas no pueden ejecutar las tareas de gulp. Cambio 3b8716a nos deja usar yarn para compilar html, estilos y imágenes

```
yarn html - compilar html
yarn styles - compilar estilos
yarn images - compilar imágenes
```

### Todos

- [x] Revisar

### Áreas impactadas



### Pasos para reproducir

En esta rama ejecuta 

```
yarn html - compilar html
yarn styles - compilar estilos
yarn images - compilar imágenes
```
Debe hacer lo que dice :) 

