### PR TITLE
Fix incorrect html closing tag

### DIFF
--- a/app/modules/scholar/scholar.macro.html
+++ b/app/modules/scholar/scholar.macro.html
@@ -2,7 +2,7 @@
 <article class="scholar-block">
     <figure class="scholar-figure">
       <img src="/assets/img/team-foto.jpg" alt="imagen of member">
-    </figre>
+    </figure>
 
   <div class="scholar-content">
       <h2>{{ data.name }}</h2>


### PR DESCRIPTION
### Issues

The closing html figure tag was misspelled

### Todos

No applicable

### Áreas impactadas

  app/modules/scholar/scholar.macro.html 

### Pasos para reproducir

Visit a page that utilize scholar-macro and verify that the page renders correctly


