### PR TITLE
Add "intro" to About page in Spanish

### DIFF
--- a/content/es/sobre.yml
+++ b/content/es/sobre.yml
@@ -10,6 +10,8 @@ es:
     hero:
       headline: Sobre
       image: /assets/img/header-foto.jpg
+  
+    intro: Esta es una introdución a esta página
 
     web_team:
       members:


### PR DESCRIPTION
### Issues

_Add "intro" to "about" page in Spanish so that it be equal to about page in English

### Todos

_Nothing left to do

### Áreas impactadas

_Only the about page in Spanish

### Pasos para reproducir

_Review the changes


